### PR TITLE
Bug: Formatting README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,23 @@ Configurable achievements.
 
 add some sort of enemies (layered images to the clickArea )
 
-**Plugins**  
+#### Plugins
   
-Make eventlisteners (as waits) to specific actions and call specific methods/functions in a spearated layer. This layer would work as a gateway to allow users/develoeprs to create "plugin-like" features and call them throught the use of this separated group of functions.: TigFW --> eventListener to action (eg.: buy item) --> calls action on gateway layer --> if exist calls method specified by developer on some external file.  
-**Themes** 
+Make eventlisteners (as waits) to specific actions and call specific methods/functions in a spearated layer. This layer would work as a gateway to allow users/develoeprs to create "plugin-like" features and call them throught the use of this separated group of functions.: TigFW --> eventListener to action (eg.: buy item) --> calls action on gateway layer --> if exist calls method specified by developer on some external file.
+
+#### Themes
+
 Maybe it is a good idea to define a folder to "themes" and create some reusable css themes: Medieval, Space, Futuristic/IT, etc  
-**Layers**  
+
+#### Layers
+
 Maybe it is a good idea to allow the developer to define "layers" to the playarea, this way could be possible to overlap some content with other more relevant for a specific set of time, let say display an treasure box in front of an enemy.
-**Tests**  
+
+#### Tests
+
 Define a test framework and use it to make sure everything is work as it should.
 Resources Tests: (ResourceManagerTests.js)
+
 ---
 
 ## File Structure


### PR DESCRIPTION
Some kind of bug in the Markdown parser caused the whole lot to be emboldened, rather than only the subheadings